### PR TITLE
commandline and names fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern 
 ### Installation
 
 ```
-$ yarn
+yarn
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+yarn start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
@@ -20,7 +20,7 @@ This command starts a local development server and open up a browser window. Mos
 ### Build
 
 ```
-$ yarn build
+yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -28,7 +28,7 @@ This command generates static content into the `build` directory and can be serv
 ### Deployment
 
 ```
-$ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
+GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/docs/cn/adaptors/ble.md
+++ b/docs/cn/adaptors/ble.md
@@ -32,7 +32,7 @@ BLE适配器实现了蓝牙协议的支持，并用于定义所连接的BLE设�
 ## 使用方式
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
 ```
 
 ## 权限

--- a/docs/cn/adaptors/dummy.md
+++ b/docs/cn/adaptors/dummy.md
@@ -30,7 +30,7 @@ Dummy适配器是Octopus一种用于测试和Demo的模拟适配器。
 ## 使用方式
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
 ```
 
 ## 权限
@@ -277,59 +277,59 @@ DummyProtocolDevicePropertyType 描述了设备属性的类型。
 1. 创建一个[DeviceLink](https://github.com/cnrancher/octopus/blob/master/adaptors/dummy/deploy/e2e/dl_specialdevice.yaml)以连接DummySpecialDevice，该设备模拟客厅的风扇。
 
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice.yaml
     ```
    
     将上面创建的风扇状态同步到远程MQTT代理服务器。
     
     ```shell script
     # create a Generic Secret to store the CA for connecting test.mosquitto.org.
-    $ kubectl create secret generic living-room-fan-mqtt-ca --from-file=ca.crt=./test/integration/physical/testdata/mosquitto.org.crt
+    kubectl create secret generic living-room-fan-mqtt-ca --from-file=ca.crt=./test/integration/physical/testdata/mosquitto.org.crt
    
     # create a TLS Secret to store the TLS/SSL keypair for connecting test.mosquitto.org.
-    $ kubectl create secret tls living-room-fan-mqtt-tls --key ./test/integration/physical/testdata/client-key.pem --cert ./test/integration/physical/testdata/client.crt
+    kubectl create secret tls living-room-fan-mqtt-tls --key ./test/integration/physical/testdata/client-key.pem --cert ./test/integration/physical/testdata/client.crt
    
     # publish status to test.mosquitto.org
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice_with_mqtt.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice_with_mqtt.yaml
     ```
     
     使用[`mosquitto_sub`](https://mosquitto.org/man/mosquitto_sub-1.html)工具观看同步状态。
     
     ```shell script
     # get mqtt broker server
-    $ kubectl get dummyspecialdevices.devices.edge.cattle.io living-room-fan -o jsonpath="{.status.extension.mqtt.client.server}"
+    kubectl get dummyspecialdevices.devices.edge.cattle.io living-room-fan -o jsonpath="{.status.extension.mqtt.client.server}"
    
     # get topic name
-    $ kubectl get dummyspecialdevices.devices.edge.cattle.io living-room-fan -o jsonpath="{.status.extension.mqtt.message.topicName}"
+    kubectl get dummyspecialdevices.devices.edge.cattle.io living-room-fan -o jsonpath="{.status.extension.mqtt.message.topicName}"
     # use mosquitto_sub
    
-    $ mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
+    mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
     # mosquitto_sub -h test.mosquitto.org -p 1883 -t cattle.io/octopus/default/living-room-fan 
     ```
    
 1. 创建一个[DeviceLink](https://github.com/cnrancher/octopus/blob/master/adaptors/dummy/deploy/e2e/dl_protocoldevice.yaml)以连接DummyProtocolDevice，该设备模拟一个智能机器人，它可以在2秒内随机填充所需的属性。
 
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice.yaml
     ```
    
     将以上创建的机械的答案同步到远程MQTT代理服务器。
         
     ```shell script
     # publish status to test.mosquitto.org
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice_with_mqtt.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice_with_mqtt.yaml
     ```
     
     使用[`mosquitto_sub`](https://mosquitto.org/man/mosquitto_sub-1.html)工具观看同步的结果。
     
     ```shell script
     # get mqtt broker server
-    $ kubectl get dummyprotocoldevices.devices.edge.cattle.io localhost-robot -o jsonpath="{.status.extension.mqtt.client.server}"
+    kubectl get dummyprotocoldevices.devices.edge.cattle.io localhost-robot -o jsonpath="{.status.extension.mqtt.client.server}"
    
     # get topic name
-    $ kubectl get dummyprotocoldevices.devices.edge.cattle.io localhost-robot -o jsonpath="{.status.extension.mqtt.message.topicName}"
+    kubectl get dummyprotocoldevices.devices.edge.cattle.io localhost-robot -o jsonpath="{.status.extension.mqtt.message.topicName}"
    
     # use mosquitto_sub
-    $ mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
+    mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
     # mosquitto_sub -h test.mosquitto.org -p 1883 -t cattle.io/octopus/835aea2e-5f80-4d14-88f5-40c4bda41aa3
     ```

--- a/docs/cn/adaptors/modbus.md
+++ b/docs/cn/adaptors/modbus.md
@@ -45,7 +45,7 @@ Modbus适配器实现了[goburrow/modbus](#github.com/goburrow/modbus)，支持T
 ## 使用方式
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/modbus/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/modbus/deploy/e2e/all_in_one.yaml
 
 ```
 

--- a/docs/cn/adaptors/mqtt.md
+++ b/docs/cn/adaptors/mqtt.md
@@ -522,11 +522,11 @@ spec:
    
 1. 使用[`deploy/e2e`](https://github.com/cnrancher/octopus/tree/master/deploy/e2e)部署DeviceLink
     ```shell script
-    $ kubeclt apply -f roomlightcase1.yaml
+    kubeclt apply -f roomlightcase1.yaml
     ```
 1. 检查集群中设备的状态
     ```shell script
-    $ kubeclt get mqttdevice mqtt-test -oyaml
+    kubeclt get mqttdevice mqtt-test -oyaml
     ```
 
 1. 如果安装成功，应该返回如下信息：
@@ -568,7 +568,7 @@ spec:
 1. 您可以修改设备属性，如下所示：
 
     ```shell script
-    $ kubectl edit dl mqtt-test
+    kubectl edit dl mqtt-test
     ```
 
     ```yaml

--- a/docs/cn/adaptors/opc-ua.md
+++ b/docs/cn/adaptors/opc-ua.md
@@ -32,7 +32,7 @@ OPC-UA适配器集成了[gopcua](https://github.com/gopcua/opcua)，并专注于
 ## 使用方式
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
 ```
 
 ## 权限

--- a/docs/cn/installation.md
+++ b/docs/cn/installation.md
@@ -19,28 +19,28 @@ Octopus支持两种不同的部署方式，一种是基于[Helm chart](https://h
 为了能够使用此存储库中的图表，请将下列名称和URL添加到您的Helm客户端：
 
 ```console
-$ helm repo add octopus http://charts.cnrancher.cn/octopus
-$ helm repo update
+helm repo add octopus http://charts.cnrancher.cn/octopus
+helm repo update
 ```
 
 ### 安装应用
 
 请运行以下命令，将Octopus Chart安装到Kubernetes或k3s集群中：
 ```
-$ kubectl create ns octopus-system
+kubectl create ns octopus-system
 ```
 ```
-$ helm install --namespace octopus-system myapp octopus/octopus
+helm install --namespace octopus-system myapp octopus/octopus
 ```
 
 安装成功后，您可以获取应用状态：
 ```
-$ helm status myapp
+helm status myapp
 ```
 
 如果要删除应用，请使用以下命令：
 ```
-$ helm delete myapp
+helm delete myapp
 ```
 该命令几乎删除了与应用关联的所有Kubernetes组件，并删除了Kubernetes发行版。
 
@@ -56,16 +56,16 @@ Octopus使用 `Kustomize`生成其安装程序的清单文件，安装程序YAML
 
 1. 安装Octopus
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
     ```
 
 1. 安装Octopus官方的协议适配器(包含Modbus、OPC-UA、BLE、MQTT和Dummy)
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/modbus/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/mqtt/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/modbus/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/mqtt/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
     ```
 
 ### 动画快速演示

--- a/docs/cn/octopus-ui.md
+++ b/docs/cn/octopus-ui.md
@@ -12,7 +12,7 @@ Octopus-UI当前仅适用于k3s集群。
 
 默认情况下，`Octopus-UI`在Octopus[Helm图表](./install#1-octopus-helm-应用)安装时会自动部署，您始终可以使用以下命令将其打开或关闭：
 ```shell script
-$ helm upgrade -n octopus-system --set octopus-api-server.enabled=true octopus cnrancher/octopus
+helm upgrade -n octopus-system --set octopus-api-server.enabled=true octopus cnrancher/octopus
 ```
 
 
@@ -21,17 +21,17 @@ $ helm upgrade -n octopus-system --set octopus-api-server.enabled=true octopus c
 通过`all-in-one` YAML文件来部署 `Octopus-UI`：
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus-api-server/master/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus-api-server/master/deploy/e2e/all_in_one.yaml
 ```
 
 通过检查其pod和服务状态来验证 `Octopus-UI`的状态。
 ```shell script
-$ kubectl get po -n kube-system -l app.kubernetes.io/name=octopus-api-server
+kubectl get po -n kube-system -l app.kubernetes.io/name=octopus-ui
 
 NAME                                      READY   STATUS      RESTARTS   AGE
 rancher-octopus-api-server-5c845c998b-pj2gr          1/1     Running     1          20s
 
-$ kubectl get svc -n kube-system -l app.kubernetes.io/name=octopus-api-server
+kubectl get svc -n kube-system -l app.kubernetes.io/name=octopus-ui
 NAME              TYPE           CLUSTER-IP    EXTERNAL-IP                PORT(S)          AGE
 rancher-octopus-api-server   LoadBalancer   10.43.98.95   172.16.1.89,192.168.0.90   8443:31520/TCP   22s
 ```

--- a/docs/cn/quick-start.md
+++ b/docs/cn/quick-start.md
@@ -23,7 +23,7 @@ title: 快速入门指南
 1. 运行以下指令，启动具有3个worker节点的本地k3s集群。
     
     ```shell script 
-    $ curl -fL https://octopus-assets.oss-cn-beijing.aliyuncs.com/k3d/cluster-k3s-spinup.sh | bash -
+    curl -fL https://octopus-assets.oss-cn-beijing.aliyuncs.com/k3d/cluster-k3s-spinup.sh | bash -
     ```
    
    :::note说明
@@ -57,12 +57,12 @@ title: 快速入门指南
 
 1. 打开一个新终端，并配置`KUBECONFIG`以访问本地k3s集群。
     ```shell script 
-    $ export KUBECONFIG=~/.kube/rancher-k3s.yaml
+    export KUBECONFIG=~/.kube/rancher-k3s.yaml
     ```
    
 1. 运行`kubectl get node`命令， 检查本地k3s集群的节点是否正常。
     ```shell script 
-    $ kubectl get node
+  kubectl get node
    NAME                 STATUS   ROLES    AGE     VERSION
    edge-control-plane   Ready    master   3m46s   v1.17.2+k3s1
    edge-worker2         Ready    <none>   3m8s    v1.17.2+k3s1
@@ -74,7 +74,7 @@ title: 快速入门指南
 有[两种部署Octopus的方法](./install)，为方便起见，我们将通过一份 `all-in-one`的YAML文件来部署。 安装程序YAML文件位于Github上的[`deploy/e2e`](https://github.com/cnrancher/octopus/tree/master/deploy/e2e)目录下：
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/deploy/e2e/all_in_one.yaml
 ```
 
 预期结果：
@@ -93,7 +93,7 @@ daemonset.apps/octopus-limb created
 
 安装后，我们可以验证Octopus的状态，如下所示：
 ```shell script
-$ kubectl get all -n octopus-system
+kubectl get all -n octopus-system
 NAME                                 READY   STATUS    RESTARTS   AGE
 pod/octopus-limb-w8vcf               1/1     Running   0          14s
 pod/octopus-limb-862kh               1/1     Running   0          14s
@@ -205,7 +205,7 @@ status:
 虚拟设备适配器（Dummy Adaptor）的安装YAML文件位于[`adaptors/dummy/deploy/e2e`](https://github.com/cnrancher/octopus/blob/master/adaptors/dummy/deploy/e2e)目录下，即 `all_in_one.yaml`, 它包含了设备模型和设备适配器，我们可以通过以下指令将其直接部署到k3s集群中：
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
 ```
 
 预期结果：
@@ -216,7 +216,7 @@ clusterrole.rbac.authorization.k8s.io/octopus-adaptor-dummy-manager-role created
 clusterrolebinding.rbac.authorization.k8s.io/octopus-adaptor-dummy-manager-rolebinding created
 daemonset.apps/octopus-adaptor-dummy-adaptor created
 
-$ kubectl get all -n octopus-system
+kubectl get all -n octopus-system
 NAME                                      READY   STATUS    RESTARTS   AGE
 pod/octopus-limb-w8vcf                    1/1     Running   0          2m27s
 pod/octopus-limb-862kh                    1/1     Running   0          2m27s
@@ -288,13 +288,13 @@ spec:
         location: "living_room"
       gear: slow
       "on": true
-
+EOF
 ```
 
 DeviceLink包含了[几种状态](./devicelink/state-of-dl)，如果我们发现其`PHASE`为**DeviceConnected**和`STATUS`为**Healthy**的状态下，我们就可以使用设备模型的CRD对象来查询其状态（即此处的dummyspecialdevice）：
 
 ```shell script
-$ kubectl get devicelink living-room-fan -n default
+kubectl get devicelink living-room-fan -n default
 NAME              KIND                 NODE          ADAPTOR                         PHASE             STATUS    AGE
 living-room-fan   DummySpecialDevice   edge-worker   adaptors.edge.cattle.io/dummy   DeviceConnected   Healthy   10s
 
@@ -302,7 +302,7 @@ living-room-fan   DummySpecialDevice   edge-worker   adaptors.edge.cattle.io/dum
 
 查看虚拟设备上报的状态或信息：
 ```shell script
-$ kubectl get dummyspecialdevice living-room-fan -n default -w
+kubectl get dummyspecialdevice living-room-fan -n default -w
 NAME              GEAR   SPEED   AGE
 living-room-fan   slow   10      32s
 living-room-fan   slow   11      33s
@@ -315,17 +315,17 @@ living-room-fan   slow   12      36s
 用户可以使用修改设备属性来管理其设备，例如，假设我们要关闭风扇，可以将其`on`(开关属性)配置设置为 `"on"：false`：
 
 ```shell script
-$ kubectl patch devicelink living-room-fan -n default --type merge --patch '{"spec":{"template":{"spec":{"on":false}}}}'
+kubectl patch devicelink living-room-fan -n default --type merge --patch '{"spec":{"template":{"spec":{"on":false}}}}'
 ```
 
 日志显示 `devicelink.edge.cattle.io/living-room-fan is patched`，查询其状态，`GEAR`和`SPEED`值均显示为空值(表示已关闭)。
 
 ```
-$ kubectl get devicelink living-room-fan -n default
+kubectl get devicelink living-room-fan -n default
   NAME              KIND                 NODE          ADAPTOR                         PHASE             STATUS    AGE
   living-room-fan   DummySpecialDevice   edge-worker   adaptors.edge.cattle.io/dummy   DeviceConnected   Healthy   89s
 
-$ kubectl get dummyspecialdevice living-room-fan -n default
+kubectl get dummyspecialdevice living-room-fan -n default
 NAME              GEAR   SPEED   AGE
 living-room-fan                  117s
 ```

--- a/docs/en/adaptors/ble.md
+++ b/docs/en/adaptors/ble.md
@@ -34,7 +34,7 @@ BLE adaptor implements on [bettercap/gatt](#github.com/bettercap/gatt) and helps
 ## Usage
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
 ```
 
 ## Authority

--- a/docs/en/adaptors/dummy.md
+++ b/docs/en/adaptors/dummy.md
@@ -31,7 +31,7 @@ Dummy is used to quickly experience Octopus. The Dummy adaptor can simulate the 
 ## Usage
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
 ```
 
 ## Authority
@@ -276,62 +276,62 @@ Parameter | Description | Schema | Required
 1. Create a [DeviceLink](https://github.com/cnrancher/octopus/blob/master/adaptors/dummy/deploy/e2e/dl_specialdevice.yaml) to connect the DummySpecialDevice, which simulates a fan of living room. 
 
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice.yaml
     ```
     
     Synchronize the above-created fan's status to the remote MQTT broker server.
     
     ```shell script
     # create a Generic Secret to store the CA for connecting test.mosquitto.org.
-    $ kubectl create secret generic living-room-fan-mqtt-ca --from-file=ca.crt=./test/integration/physical/testdata/mosquitto.org.crt
+    kubectl create secret generic living-room-fan-mqtt-ca --from-file=ca.crt=./test/integration/physical/testdata/mosquitto.org.crt
    
     # create a TLS Secret to store the TLS/SSL keypair for connecting test.mosquitto.org.
-    $ kubectl create secret tls living-room-fan-mqtt-tls --key ./test/integration/physical/testdata/client-key.pem --cert ./test/integration/physical/testdata/client.crt
+    kubectl create secret tls living-room-fan-mqtt-tls --key ./test/integration/physical/testdata/client-key.pem --cert ./test/integration/physical/testdata/client.crt
    
     # publish status to test.mosquitto.org
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice_with_mqtt.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_specialdevice_with_mqtt.yaml
     ```
     
     Use [`mosquitto_sub`](https://mosquitto.org/man/mosquitto_sub-1.html) tool to watch the synchronized status.
     
     ```shell script
     # get mqtt broker server
-    $ kubectl get dl living-room-fan -o jsonpath="{.spec.template.spec.extension.mqtt.client.server}"
+    kubectl get dl living-room-fan -o jsonpath="{.spec.template.spec.extension.mqtt.client.server}"
    
     # get topic name
-    $ kubectl get dl living-room-fan -o jsonpath="{.spec.template.spec.extension.mqtt.message.topic}"
+    kubectl get dl living-room-fan -o jsonpath="{.spec.template.spec.extension.mqtt.message.topic}"
 
     # use mosquitto_sub
-    $ mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
+    mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
     # mosquitto_sub -h test.mosquitto.org -p 1883 -t cattle.io/octopus/default/living-room-fan 
     ```
    
 1. Create a [DeviceLink](./deploy/e2e/dl_protocoldevice.yaml) to connect the DummyProtocolDevice, which simulates an intelligent property-filled robot, it can fill the desired properties randomly in 2 seconds.
 
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice.yaml
     ```
    
     Synchronize the above-created robot's answers to the remote MQTT broker server.
         
     ```shell script
     # publish status to test.mosquitto.org
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice_with_mqtt.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/dl_protocoldevice_with_mqtt.yaml
     ```
     
     Use [`mosquitto_sub`](https://mosquitto.org/man/mosquitto_sub-1.html) tool to watch the synchronized answers.
     
     ```shell script
     # get mqtt broker server
-    $ kubectl get dl localhost-robot -o jsonpath="{.spec.template.spec.extension.mqtt.client.server}"
+    kubectl get dl localhost-robot -o jsonpath="{.spec.template.spec.extension.mqtt.client.server}"
    
     # get topic name
-    $ kubectl get dl localhost-robot -o jsonpath="{.spec.template.spec.extension.mqtt.message.topic}"
+    kubectl get dl localhost-robot -o jsonpath="{.spec.template.spec.extension.mqtt.message.topic}"
 
     # get dl uid
-    $ kubectl get dl localhost-robot -o jsonpath="{.metadata.uid}"
+    kubectl get dl localhost-robot -o jsonpath="{.metadata.uid}"
    
     # use mosquitto_sub
-    $ mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
+    mosquitto_sub -h {the host of mqtt broker server} -p {the port of mqtt broker server} -t {the topic name}
     # mosquitto_sub -h test.mosquitto.org -p 1883 -t cattle.io/octopus/835aea2e-5f80-4d14-88f5-40c4bda41aa3
     ```

--- a/docs/en/adaptors/opc-ua.md
+++ b/docs/en/adaptors/opc-ua.md
@@ -32,7 +32,7 @@ OPC-UA adaptor implements on [gopcua/opcua](https://github.com/gopcua/opcua) and
 ## Usage
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
 ```
 
 ## Authority

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -19,28 +19,28 @@ The [Octopus-Chart](https://github.com/cnrancher/octopus-chart) repository hosts
 In order to be able to use the charts in this repository, add the name and URL to your Helm client:
 
 ```console
-$ helm repo add octopus http://charts.cnrancher.cn/octopus
-$ helm repo update
+helm repo add octopus http://charts.cnrancher.cn/octopus
+helm repo update
 ```
 
 ### Installing the Chart
 
 To install the Octopus Chart into your Kubernetes/k3s cluster use:
 ```
-$ kubectl create ns octopus-system
+kubectl create ns octopus-system
 ```
 ```
-$ helm install --namespace octopus-system myapp octopus/octopus
+helm install --namespace octopus-system myapp octopus/octopus
 ```
 
 After installation succeeds, you can get a status of Chart
 ```
-$ helm status myapp
+helm status myapp
 ```
 
 If you want to delete your Chart, use this command:
 ```
-$ helm delete myapp
+helm delete myapp
 ```
 
 The command removes nearly all the Kubernetes components associated with the
@@ -58,16 +58,16 @@ Octopus uses `Kustomize` to generate its installer manifest files, the installer
 
 1. Install Octopus
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
     ```
 
 1. Install Octopus Official Adaptors
     ```shell script
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/modbus/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/mqtt/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
-    $ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/modbus/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/opcua/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/mqtt/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/ble/deploy/e2e/all_in_one.yaml
+    kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
     ```
 
 ### Animated quick demo

--- a/docs/en/octopus-ui.md
+++ b/docs/en/octopus-ui.md
@@ -11,7 +11,7 @@ Octopus-UI is only supported for k3s cluster.
 ## Install Octopus-UI from Helm
 By default, the `Octopus-UI` is auto deployed using octopus [Helm chart](./install#1-octopus-helm-chart), you can always turn it on or off with following commands:
 ```shell script
-$ helm upgrade -n octopus-system --set octopus-api-server.enabled=true octopus cnrancher/octopus
+helm upgrade -n octopus-system --set octopus-api-server.enabled=true octopus cnrancher/octopus
 ```
 
 
@@ -20,17 +20,17 @@ $ helm upgrade -n octopus-system --set octopus-api-server.enabled=true octopus c
 Deploy the `Octopus-UI` using `all-in-one` YAML file:
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus-api-server/master/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus-api-server/master/deploy/e2e/all_in_one.yaml
 ```
 
 Validate the `Octopus-UI` status by checking its pod and service status.
 ```shell script
-$ kubectl get po -n kube-system -l app.kubernetes.io/name=octopus-api-server
+kubectl get po -n kube-system -l app.kubernetes.io/name=octopus-ui
 
 NAME                                      READY   STATUS      RESTARTS   AGE
 rancher-octopus-api-server-5c845c998b-pj2gr          1/1     Running     1          20s
 
-$ kubectl get svc -n kube-system -l app.kubernetes.io/name=octopus-api-server
+kubectl get svc -n kube-system -l app.kubernetes.io/name=octopus-ui
 NAME              TYPE           CLUSTER-IP    EXTERNAL-IP                PORT(S)          AGE
 rancher-octopus-api-server   LoadBalancer   10.43.98.95   172.16.1.89,192.168.0.90   8443:31520/TCP   22s
 ```

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -12,7 +12,7 @@ You should either have an existing k3s or Kubernetes cluster to deploy the Octop
 
 1. Spin-up a local k3d cluster with 3 worker nodes on default.
     ```shell script 
-    $ curl -fL https://octopus-assets.oss-cn-beijing.aliyuncs.com/k3d/cluster-k3s-spinup.sh | bash -
+    curl -fL https://octopus-assets.oss-cn-beijing.aliyuncs.com/k3d/cluster-k3s-spinup.sh | bash -
     ```
    
    :::note
@@ -46,12 +46,12 @@ You should either have an existing k3s or Kubernetes cluster to deploy the Octop
 
 1. Open a new terminal and set the `KUBECONFIG` to access the local k3s cluster.
     ```shell script 
-    $ export KUBECONFIG=~/.kube/rancher-k3s.yaml
+    export KUBECONFIG=~/.kube/rancher-k3s.yaml
     ```
    
 1. Validate the local k3s cluster by checking its node.
     ```shell script 
-    $ kubectl get node
+    kubectl get node
    NAME                 STATUS   ROLES    AGE     VERSION
    edge-control-plane   Ready    master   3m46s   v1.17.2+k3s1
    edge-worker2         Ready    <none>   3m8s    v1.17.2+k3s1
@@ -74,7 +74,7 @@ In this walk-through, we will use Octopus to manage a `dummy` device and perform
 There are [two ways](./install) to deploy the Octopus, for convenience, we will use the manifest YAML file to bring up the Octopus. The installer YAML file is under the [`deploy/e2e`](https://github.com/cnrancher/octopus/tree/master/deploy/e2e) directory on Github:
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/deploy/e2e/all_in_one.yaml
 ```
 
 expected result:
@@ -94,7 +94,7 @@ daemonset.apps/octopus-limb created
 After installed, we can verify the status of Octopus as below:
 
 ```shell script
-$ kubectl get all -n octopus-system
+kubectl get all -n octopus-system
 NAME                                 READY   STATUS    RESTARTS   AGE
 pod/octopus-limb-w8vcf               1/1     Running   0          14s
 pod/octopus-limb-862kh               1/1     Running   0          14s
@@ -202,7 +202,7 @@ status:
 The dummy adaptor installer YAML file is under the [`adaptors/dummy/deploy/e2e`](https://github.com/cnrancher/octopus/blob/master/adaptors/dummy/deploy/e2e) directory, the `all_in_one.yaml` contains the device model and the device adaptor, we can apply it into the cluster directly:
 
 ```shell script
-$ kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
+kubectl apply -f https://raw.githubusercontent.com/cnrancher/octopus/master/adaptors/dummy/deploy/e2e/all_in_one.yaml
 ```
 
 expected result:
@@ -213,7 +213,7 @@ clusterrole.rbac.authorization.k8s.io/octopus-adaptor-dummy-manager-role created
 clusterrolebinding.rbac.authorization.k8s.io/octopus-adaptor-dummy-manager-rolebinding created
 daemonset.apps/octopus-adaptor-dummy-adaptor created
 
-$ kubectl get all -n octopus-system
+kubectl get all -n octopus-system
 NAME                                      READY   STATUS    RESTARTS   AGE
 pod/octopus-limb-w8vcf                    1/1     Running   0          2m27s
 pod/octopus-limb-862kh                    1/1     Running   0          2m27s
@@ -244,7 +244,7 @@ replicaset.apps/octopus-brain-65fdb4ff99   1         1         1       2m27s
 Notes that we have also granted Octopus permission to managing `DummySpecialDevice`/`DummyProtocolDevice`:
 
 ```shell script
-$ kubectl get clusterrolebinding | grep octopus
+kubectl get clusterrolebinding | grep octopus
 octopus-manager-rolebinding                            2m49s
 octopus-adaptor-dummy-manager-rolebinding              43s
 
@@ -282,13 +282,13 @@ spec:
         location: "living_room"
       gear: slow
       "on": true
-
+EOF
 ```
 
 There are [several states](./devicelink/state-of-dl) of a DeviceLink, if we found the `PHASE` is **DeviceConnected** and its `STATUS` is on **Healthy**, we can now query its status use the same `DeviceLink` name of device model CRD(i.e dummyspecialdevice in here):
 
 ```shell script
-$ kubectl get devicelink living-room-fan -n default
+kubectl get devicelink living-room-fan -n default
 NAME              KIND                 NODE          ADAPTOR                         PHASE             STATUS    AGE
 living-room-fan   DummySpecialDevice   edge-worker   adaptors.edge.cattle.io/dummy   DeviceConnected   Healthy   10s
 
@@ -296,7 +296,7 @@ living-room-fan   DummySpecialDevice   edge-worker   adaptors.edge.cattle.io/dum
 
 Check device reported status:
 ```shell script
-$ kubectl get dummyspecialdevice living-room-fan -n default -w
+kubectl get dummyspecialdevice living-room-fan -n default -w
 NAME              GEAR   SPEED   AGE
 living-room-fan   slow   10      32s
 living-room-fan   slow   11      33s
@@ -309,17 +309,17 @@ living-room-fan   slow   12      36s
 Users can use device spec properties to manage its device, e.g, if we want to turn off the fan, we can set its spec `"on": false`:
 
 ```shell script
-$ kubectl patch devicelink living-room-fan -n default --type merge --patch '{"spec":{"template":{"spec":{"on":false}}}}'
+kubectl patch devicelink living-room-fan -n default --type merge --patch '{"spec":{"template":{"spec":{"on":false}}}}'
 ```
 
 the log shows `devicelink.edge.cattle.io/living-room-fan is patched`, query its status, both `GEAR` and `SPEED` shows an empty value.
 
 ```
-$ kubectl get devicelink living-room-fan -n default
+kubectl get devicelink living-room-fan -n default
   NAME              KIND                 NODE          ADAPTOR                         PHASE             STATUS    AGE
   living-room-fan   DummySpecialDevice   edge-worker   adaptors.edge.cattle.io/dummy   DeviceConnected   Healthy   89s
 
-$ kubectl get dummyspecialdevice living-room-fan -n default
+kubectl get dummyspecialdevice living-room-fan -n default
 NAME              GEAR   SPEED   AGE
 living-room-fan                  117s
 ```


### PR DESCRIPTION
修复 @海龙 提到的几个快速入门文档问题： 

- 部署Octopus，文档中的yaml连接错误，已修复 https://github.com/cnrancher/docs-octopus/pull/23
- 文档的命令行应该去掉$符号，全量排查并修改文档中有$符号的命令行语句，已修改
- YAML示例缺少 EOF，已添加
- 示例中的标签错误，已修改